### PR TITLE
Remove CC0 exception for constant_time_eq

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,6 @@ allow = [
 ]
 exceptions = [
     { allow = ["Unicode-DFS-2016"], name = "unicode-ident" },
-    { allow = ["CC0-1.0"], name = "constant_time_eq" },
 ]
 private.ignore = false
 


### PR DESCRIPTION
constant_time_eq is now CC0-1.0 OR MIT-0 OR Apache-2.0