### PR TITLE
Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- smrtrfszm
+- TwoDCube


### PR DESCRIPTION
## Summary
- Add `OWNERS` file at repo root listing approvers (`smrtrfszm`, `TwoDCube`), matching the format used in the Verseghy `website_backend2` repo.

## Test plan
- [x] File created with correct YAML structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)